### PR TITLE
Fix granularity for nodeSelector and tolerations 

### DIFF
--- a/charts/nutanix-csi-storage/Chart.yaml
+++ b/charts/nutanix-csi-storage/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nutanix-csi-storage
-version: 2.3.11
+version: 2.3.12
 kubeVersion: ">= 1.17.0"
 description: A Helm chart for installing Nutanix CSI Volume Driver
 home: https://github.com/nutanix/helm

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-node.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-node.yaml
@@ -89,7 +89,6 @@ spec:
             periodSeconds: 2
             failureThreshold: 3
         - name: liveness-probe
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi
               name: plugin-dir
@@ -97,11 +96,11 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
-    {{- with .Values.nodeSelector }}
+    {{- with (.Values.nodeSelectorCsiNodeNtnxPlugin | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (.Values.tolerationsCsiNodeNtnxPlugin | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -129,3 +128,4 @@ spec:
           hostPath:
             path: /
             type: Directory
+

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-provisioner.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-provisioner.yaml
@@ -32,7 +32,6 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -46,7 +45,6 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -103,11 +101,11 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
-    {{- with .Values.nodeSelector }}
+    {{- with (.Values.nodeSelectorCsiProvisionerNtnxPlugin | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (.Values.tolerationsCsiProvisionerNtnxPlugin | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/nutanix-csi-storage/templates/snapshot-controller-setup.yaml
+++ b/charts/nutanix-csi-storage/templates/snapshot-controller-setup.yaml
@@ -22,12 +22,11 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=false"
-          imagePullPolicy: Always
-    {{- with .Values.nodeSelector }}
+    {{- with (.Values.nodeSelectorSnapshotController | default .Values.nodeSelector ) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (.Values.tolerationsSnapshotController | default .Values.tolerations)}}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
In this PR i fixed the nodeSelector and tolerations so the user can apply different tolerations and nodeSelector for each deployment.

csi-provisioner-ntnx-plugin StatefulSet:
nodeSelector - if the value nodeSelectorCsiProvisionerNtnxPlugin not set it will take the default from nodeSelector.
tolerations -  if the value tolerationsCsiProvisionerNtnxPlugin not set it will take the default from tolerations.

snapshot-controller StatefulSet:
nodeSelector - if the value nodeSelectorSnapshotController not set it will take the default from nodeSelector.
tolerations -  if the value tolerationsSnapshotController not set it will take the default from tolerations.

csi-node-ntnx-plugin DaemonSet:
nodeSelector - if the value nodeSelectorCsiNodeNtnxPlugin not set it will take the default from nodeSelector.
tolerations -  if the value tolerationsCsiNodeNtnxPlugin not set it will take the default from tolerations.