### PR TITLE
Added reclaimPolicy setting via helm value for every StorageClasses

### DIFF
--- a/charts/nutanix-csi-storage/README.md
+++ b/charts/nutanix-csi-storage/README.md
@@ -106,39 +106,42 @@ helm delete nutanix-csi -n <namespace of your choice>
 
 The following table lists the configurable parameters of the Nutanix-CSI chart and their default values.
 
-|              Parameter           |                Description             |             Default            |
-|----------------------------------|----------------------------------------|--------------------------------|
-| `legacy`                         | Use old reverse notation for CSI driver name | `false` |
-| `volumeClass`                    | Activate Nutanix Volumes Storage Class | `false` |
-| `volumeClassName`                | Name of the Nutanix Volumes Storage Class | `nutanix-volume` |
-| `fileClass`                      | Activate Nutanix Files Storage Class | `false` |
-| `fileClassName`                  | Name of the Nutanix Files Storage Class | `nutanix-file` |
-| `dynamicFileClass`               | Activate Nutanix Dynamic Files Storage Class | `false` |
-| `dynamicFileClassName`           | Name of the Nutanix Dynamic Files Storage Class | `nutanix-dynamicfile` |
-| `defaultStorageClass`            | Choose your default Storage Class (none, volume, file, dynfile) | `none`|
-| `prismEndPoint`                  | Cluster Virtual IP Address |`10.0.0.1`|
-| `username`                       | Name used for the admin role (if created) |`admin`|
-| `password`                       | Password for the admin role (if created) |`nutanix/4u`|
-| `secretName`                     | Name of the secret to use for admin role| `ntnx-secret`|
-| `createSecret`                   | Create secret for admin role (if false use existing)| `true`|
-| `storageContainer`               | Nutanix storage container name     | `default`|
-| `fsType`                         | Type of file system you are using (ext4, xfs)  |`xfs`|
-| `networkSegmentation`            | Activate Volumes Network Segmentation support |`false`|
-| `lvmVolume`                      | Activate LVM to use multiple vdisks by Volume    |`false`|
-| `lvmDisks`                       | Number of vdisks by volume if lvm enabled | `4`|
-| `fileHost`                       | NFS server IP address | `10.0.0.3`|
-| `filePath`                       | Path of the NFS share |`share`|
-| `fileServerName`                 | Name of the Nutanix FIle Server | `file`|
-| `kubeletDir`                     | allows overriding the host location of kubelet's internal state | `/var/lib/kubelet`|
-| `nodeSelector`                   | Add nodeSelector to all pods | `{}` |
-| `tolerations`                    | Add tolerations to all pods | `[]` |
-| `imagePullPolicy`                | Specify imagePullPolicy for all pods| `IfNotPresent`|
-| `provisioner.nodeSelector`       | Add nodeSelector to provisioner pod | `{}` |
-| `provisioner.tolerations`        | Add tolerations to provisioner pod | `[]`  |
-| `node.nodeSelector`              | Add nodeSelector to node pods | `{}` |
-| `node.tolerations`               | Add tolerations to node pods | `[]` |
-| `servicemonitor.enabled`         | Create ServiceMonitor to scrape CSI  metrics | `false` |
-| `servicemonitor.labels`          | Labels to add to the ServiceMonitor (for match the Prometheus serviceMonitorSelector logic) | `k8s-app: csi-driver`|
+| Parameter                        | Description                                                                                 | Default               |
+|----------------------------------|---------------------------------------------------------------------------------------------|-----------------------|
+| `legacy`                         | Use old reverse notation for CSI driver name                                                | `false`               |
+| `volumeClass`                    | Activate Nutanix Volumes Storage Class                                                      | `false`               |
+| `volumeClassName`                | Name of the Nutanix Volumes Storage Class                                                   | `nutanix-volume`      |
+| `volumeClassRetention`           | Retention policy for the Volumes Storage Class (Delete, Retain)                             | `Delete`              |
+| `fileClass`                      | Activate Nutanix Files Storage Class                                                        | `false`               |
+| `fileClassName`                  | Name of the Nutanix Files Storage Class                                                     | `nutanix-file`        |
+| `fileClassRetention`             | Retention policy for the Files Storage Class (Delete, Retain)                               | `Delete`              |
+| `dynamicFileClass`               | Activate Nutanix Dynamic Files Storage Class                                                | `false`               |
+| `dynamicFileClassName`           | Name of the Nutanix Dynamic Files Storage Class                                             | `nutanix-dynamicfile` |
+| `dynamicFileClassRetention`      | Retention policy for the Dynamic Files Storage Class (Delete, Retain)                       | `Delete`              |
+| `defaultStorageClass`            | Choose your default Storage Class (none, volume, file, dynfile)                             | `none`                |
+| `prismEndPoint`                  | Cluster Virtual IP Address                                                                  | `10.0.0.1`            |
+| `username`                       | Name used for the admin role (if created)                                                   | `admin`               |
+| `password`                       | Password for the admin role (if created)                                                    | `nutanix/4u`          |
+| `secretName`                     | Name of the secret to use for admin role                                                    | `ntnx-secret`         |
+| `createSecret`                   | Create secret for admin role (if false use existing)                                        | `true`                |
+| `storageContainer`               | Nutanix storage container name                                                              | `default`             |
+| `fsType`                         | Type of file system you are using (ext4, xfs)                                               | `xfs`                 |
+| `networkSegmentation`            | Activate Volumes Network Segmentation support                                               | `false`               |
+| `lvmVolume`                      | Activate LVM to use multiple vdisks by Volume                                               | `false`               |
+| `lvmDisks`                       | Number of vdisks by volume if lvm enabled                                                   | `4`                   |
+| `fileHost`                       | NFS server IP address                                                                       | `10.0.0.3`            |
+| `filePath`                       | Path of the NFS share                                                                       | `share`               |
+| `fileServerName`                 | Name of the Nutanix FIle Server                                                             | `file`                |
+| `kubeletDir`                     | allows overriding the host location of kubelet's internal state                             | `/var/lib/kubelet`    |
+| `nodeSelector`                   | Add nodeSelector to all pods                                                                | `{}`                  |
+| `tolerations`                    | Add tolerations to all pods                                                                 | `[]`                  |
+| `imagePullPolicy`                | Specify imagePullPolicy for all pods                                                        | `IfNotPresent`        |
+| `provisioner.nodeSelector`       | Add nodeSelector to provisioner pod                                                         | `{}`                  |
+| `provisioner.tolerations`        | Add tolerations to provisioner pod                                                          | `[]`                  |
+| `node.nodeSelector`              | Add nodeSelector to node pods                                                               | `{}`                  |
+| `node.tolerations`               | Add tolerations to node pods                                                                | `[]`                  |
+| `servicemonitor.enabled`         | Create ServiceMonitor to scrape CSI  metrics                                                | `false`               |
+| `servicemonitor.labels`          | Labels to add to the ServiceMonitor (for match the Prometheus serviceMonitorSelector logic) | `k8s-app: csi-driver` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a a file whit `-f value.yaml`.
 

--- a/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
@@ -24,7 +24,7 @@ parameters:
     numLVMDisks: {{ quote .Values.lvmDisks }}
 {{- end }}
 allowVolumeExpansion: true
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.volumeClassRetention }}
 ---
 {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
 apiVersion: snapshot.storage.k8s.io/v1
@@ -56,6 +56,7 @@ parameters:
     storageType: NutanixFiles
     nfsServer: {{ .Values.fileHost }}
     nfsPath: {{ .Values.filePath }}
+reclaimPolicy: {{ .Values.fileClassRetention }}
 {{- end }}
 ---
 {{- if eq .Values.dynamicFileClass true }}
@@ -79,4 +80,5 @@ parameters:
     csi.storage.k8s.io/controller-expand-secret-name: {{ .Values.secretName }}
     csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Release.Namespace }}
 allowVolumeExpansion: true
+reclaimPolicy: {{ .Values.dynamicFileClassRetention }}
 {{- end }}

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -29,12 +29,15 @@ imagePullPolicy: IfNotPresent
 # choose for which mode (Volume, File, Dynamic File) storageclass need to be created
 volumeClass: false
 volumeClassName: "nutanix-volume"
+volumeClassRetention: "Delete"
 
 fileClass: false
 fileClassName: "nutanix-file"
+fileClassRetention: "Delete"
 
 dynamicFileClass: false
 dynamicFileClassName: "nutanix-dynamicfile"
+dynamicFileClassRetention: "Delete"
 
 
 # Default Storage Class settings


### PR DESCRIPTION
- Changed Volume Storage class reclaim policy to be settable via helm value.
- Added Files Storage class reclaim policy and made it settable
- Added Dynamic Files Storage class reclaim policy and made it settable
- Updated doc

One thing to note is that I don't know the capabilities of the nutanix-csi implementation in terms of reclaimPolicy support. I assumed here that all 3 SC supported reclaimPolicy of at least "Delete" (the default for dynamically generated PVs) but that's up to the implementation of the CSI as per https://kubernetes.io/docs/concepts/storage/persistent-volumes/#delete states it.