### PR TITLE
update CSI storage chart to v2.5.4

### DIFF
--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -1,0 +1,7 @@
+# three node (two workers) cluster config
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.6.0
 
       - name: Run chart-testing (lint-changed)
         id: list-changed
@@ -26,8 +28,10 @@ jobs:
         run: ct lint
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.3.0
         if: steps.list-changed.outputs.changed == 'true'
+        with:
+          config: .github/kind-config.yaml
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --helm-extra-set-args "--set=kindtest=true"

--- a/charts/nutanix-csi-storage/Chart.yaml
+++ b/charts/nutanix-csi-storage/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nutanix-csi-storage
-version: 2.5.3
+version: 2.5.4
 kubeVersion: ">= 1.17.0-0"
 description: Nutanix Container Storage Interface (CSI) Driver
 home: https://github.com/nutanix/helm
@@ -23,7 +23,7 @@ annotations:
   artifacthub.io/displayName: "Nutanix CSI Storage"
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - Update Nutanix CSI Driver to 2.5.1
+    - Update CSI Sidecar version
   artifacthub.io/links: |
     - name: Nutanix CSI Driver documentation
       url: https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_5:CSI-Volume-Driver-v2_5

--- a/charts/nutanix-csi-storage/README.md
+++ b/charts/nutanix-csi-storage/README.md
@@ -138,8 +138,9 @@ The following table lists the configurable parameters of the Nutanix-CSI chart a
 | `nodeSelector`                | Add nodeSelector to all pods                                                                | `{}`                   |
 | `tolerations`                 | Add tolerations to all pods                                                                 | `[]`                   |
 | `imagePullPolicy`             | Specify imagePullPolicy for all pods                                                        | `IfNotPresent`         |
-| `provisioner.nodeSelector`    | Add nodeSelector to provisioner pod                                                         | `{}`                   |
-| `provisioner.tolerations`     | Add tolerations to provisioner pod                                                          | `[]`                   |
+| `controller.replicas`         | Number of Controllers replicas to deploy.                                                   | `2`                    |
+| `controller.nodeSelector`     | Add nodeSelector to provisioner pod                                                         | `{}`                   |
+| `controller.tolerations`      | Add tolerations to provisioner pod                                                          | `[]`                   |
 | `node.nodeSelector`           | Add nodeSelector to node pods                                                               | `{}`                   |
 | `node.tolerations`            | Add tolerations to node pods                                                                | `[]`                   |
 | `servicemonitor.enabled`      | Create ServiceMonitor to scrape CSI  metrics                                                | `false`                |

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml
@@ -2,27 +2,44 @@
 #
 # example usage: kubectl create -f <this_file>
 
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: csi-provisioner-ntnx-plugin
+  name: nutanix-csi-controller
   namespace: {{ .Release.Namespace }}
 spec:
-  serviceName: csi-provisioner-ntnx-plugin
-  replicas: 1
+  replicas: {{ .Values.controller.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   selector:
     matchLabels:
-      app: csi-provisioner-ntnx-plugin
+      app: nutanix-csi-controller
   template:
     metadata:
       labels:
-        app: csi-provisioner-ntnx-plugin
+        app: nutanix-csi-controller
     spec:
-      serviceAccount: csi-provisioner
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nutanix-csi-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccount: nutanix-csi-controller
       hostNetwork: true
       containers:
         - name: csi-provisioner
+          {{- if semverCompare ">=1.20-0"  .Capabilities.KubeVersion.Version }}
           image: {{ .Values.sidecars.provisioner.image }}
+          {{- else }}
+          image: {{ .Values.sidecars.provisioner.imageLegacy }}
+          {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
@@ -33,7 +50,8 @@ spec:
             - --default-fstype=ext4
             # This is used to collect CSI operation metrics
             - --http-endpoint=:9809
-            - --v=5
+            - --v=2
+            - --leader-election=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -51,10 +69,10 @@ spec:
           image: {{ .Values.sidecars.resizer.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
-            - --v=5
+            - --v=2
             - --csi-address=$(ADDRESS)
             - --timeout=60s
-            - --leader-election=false
+            - --leader-election=true
             # NTNX CSI dirver supports online volume expansion.
             - --handle-volume-inuse-error=false
             - --http-endpoint=:9810
@@ -73,7 +91,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
           - --csi-address=$(ADDRESS)
-          - --leader-election=false
+          - --leader-election=true
           - --logtostderr=true
           - --timeout=300s
           env:
@@ -82,8 +100,8 @@ spec:
           volumeMounts:
           - name: socket-dir
             mountPath: /csi
-        - name: ntnx-csi-plugin
-          image: {{ .Values.provisioner.image }}
+        - name: nutanix-csi-plugin
+          image: {{ .Values.controller.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: true
@@ -133,11 +151,12 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=:9807
-    {{- with (.Values.provisioner.nodeSelector | default .Values.nodeSelector) }}
+      priorityClassName: system-cluster-critical
+    {{- with (.Values.controller.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with (.Values.provisioner.tolerations | default .Values.tolerations) }}
+    {{- with (.Values.controller.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml
@@ -5,25 +5,29 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: csi-node-ntnx-plugin
+  name: nutanix-csi-node
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: csi-node-ntnx-plugin
+      app: nutanix-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
-        app: csi-node-ntnx-plugin
+        app: nutanix-csi-node
     spec:
-      serviceAccount: csi-node-ntnx-plugin
+      serviceAccount: nutanix-csi-node
       hostNetwork: true
       containers:
         - name: driver-registrar
           image: {{ .Values.sidecars.registrar.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
-            - --v=5
+            - --v=2
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
           env:
@@ -47,7 +51,7 @@ spec:
               mountPath: /csi/
             - name: registration-dir
               mountPath: /registration
-        - name: csi-node-ntnx-plugin
+        - name: nutanix-csi-node
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
@@ -112,6 +116,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --http-endpoint=:9808
+      priorityClassName: system-cluster-critical
     {{- with (.Values.node.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -139,7 +144,11 @@ spec:
         - name: iscsi-dir
           hostPath:
             path: /etc/iscsi
+            {{- if eq .Values.kindtest true }}
+            type: DirectoryOrCreate
+            {{- else }}
             type: Directory
+            {{- end }}
         - name: root-dir
           hostPath:
             path: /

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
@@ -8,13 +8,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: csi-provisioner
+  name: nutanix-csi-controller
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-provisioner-runner
+  name: nutanix-csi-controller-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
@@ -49,53 +49,41 @@ rules:
     verbs: ["update"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-provisioner-role
+  name: nutanix-csi-controller-binding
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: csi-provisioner
+    name: nutanix-csi-controller
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: external-provisioner-runner
+  name: nutanix-csi-controller-role
   apiGroup: rbac.authorization.k8s.io
----
-# needed for StatefulSet
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-provisioner-ntnx-plugin
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: csi-provisioner-ntnx-plugin
-spec:
-  selector:
-    app: csi-provisioner-ntnx-plugin
-  ports:
-    - name: dummy
-      port: 12345
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: csi-node-ntnx-plugin
+  name: nutanix-csi-node
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-node-runner
+  name: nutanix-csi-node-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
@@ -117,14 +105,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-node-role
+  name: nutanix-csi-node-binding
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: csi-node-ntnx-plugin
+    name: nutanix-csi-node
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: csi-node-runner
+  name: nutanix-csi-node-role
   apiGroup: rbac.authorization.k8s.io          
 

--- a/charts/nutanix-csi-storage/templates/ntnx-csi-scc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-scc.yaml
@@ -25,6 +25,6 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-  - system:serviceaccount:{{ .Release.Namespace }}:csi-provisioner
-  - system:serviceaccount:{{ .Release.Namespace }}:csi-node-ntnx-plugin
+  - system:serviceaccount:{{ .Release.Namespace }}:nutanix-csi-controller
+  - system:serviceaccount:{{ .Release.Namespace }}:nutanix-csi-node
 {{- end}}

--- a/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
+++ b/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
@@ -6,14 +6,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: csi-metrics-service
+  name: nutanix-csi-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    app: csi-provisioner-ntnx-plugin
+    app: nutanix-csi-metrics
 spec:
   type: ClusterIP
   selector:
-    app: csi-provisioner-ntnx-plugin
+    app: nutanix-csi-controller
   ports:
     - name: provisioner
       port: 9809
@@ -32,7 +32,7 @@ metadata:
 {{- with .Values.servicemonitor.labels }}
     {{- toYaml . | nindent 4 }}
 {{- end }}
-  name: csi-driver
+  name: nutanix-csi-driver
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
@@ -42,5 +42,5 @@ spec:
     port: resizer
   selector:
     matchLabels:
-      app: csi-provisioner-ntnx-plugin
+      app: nutanix-csi-metrics
 {{- end }}

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -102,7 +102,8 @@ servicemonitor:
 # Pod pecific Settings
 #
 
-provisioner:
+controller:
+  replicas: 2
   image: quay.io/karbon/ntnx-csi:v2.5.1
   nodeSelector: {}
   tolerations: []
@@ -114,13 +115,20 @@ node:
 
 sidecars:
   registrar:
-    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
   provisioner:
-    image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0
+    imageLegacy: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
   snapshotter:
-    image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
+    image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
     imageBeta: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
   resizer:
-    image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+    image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
   livenessprobe:
-    image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+    image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+
+
+# Used for deployment test in kind cluster
+#
+
+kindtest: false


### PR DESCRIPTION
- Update CSI sidecar to latest version

```
  registrar:
    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
  provisioner:
    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.1
    imageLegacy: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
  snapshotter:
    image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
    imageBeta: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
  resizer:
    image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
  livenessprobe:
    image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
```

- Implement two provisioner version depending of k8s version >= 1.20
- fix RBAC issue csi-provisionner need patch volumesnapshotcontents
- change architecture to HA deployment for CSI controller
- standardize ressources name