### PR TITLE
[CSI v2.6.0] Helm changes  to support CSI 2.6.0 Release

### DIFF
--- a/charts/nutanix-csi-storage/Chart.yaml
+++ b/charts/nutanix-csi-storage/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nutanix-csi-storage
-version: 2.5.4
+version: 2.6.0
 kubeVersion: ">= 1.17.0-0"
 description: Nutanix Container Storage Interface (CSI) Driver
 home: https://github.com/nutanix/helm
@@ -8,7 +8,7 @@ maintainers:
 - name: nutanix-cloud-native-bot
   email: cloudnative@nutanix.com
 icon: https://avatars2.githubusercontent.com/u/6165865?s=200&v=4
-appVersion: "2.5.1"
+appVersion: "2.6.0"
 keywords:
   - Nutanix
   - Storage

--- a/charts/nutanix-csi-storage/README.md
+++ b/charts/nutanix-csi-storage/README.md
@@ -118,7 +118,6 @@ The following table lists the configurable parameters of the Nutanix-CSI chart a
 | `fileClass`                   | Activate Nutanix Files Storage Class                                                        | `false`                |
 | `fileClassName`               | Name of the Nutanix Files Storage Class                                                     | `nutanix-file`         |
 | `fileClassRetention`          | Retention policy for the Files Storage Class (Delete, Retain)                               | `Delete`               |
-| `fileSquashType`              | Squash type for NFS Volume (none, root-squash, all-squash)                                  | `root-squash`          |
 | `dynFileSquashType`           | Squash type for Nutanix Dynamic File Storage (none, root-squash, all-squash)                | `root-squash`          |
 | `dynamicFileClass`            | Activate Nutanix Dynamic Files Storage Class                                                | `false`                |
 | `dynamicFileClassName`        | Name of the Nutanix Dynamic Files Storage Class                                             | `nutanix-dynamicfile`  |

--- a/charts/nutanix-csi-storage/README.md
+++ b/charts/nutanix-csi-storage/README.md
@@ -118,7 +118,7 @@ The following table lists the configurable parameters of the Nutanix-CSI chart a
 | `fileClass`                   | Activate Nutanix Files Storage Class                                                        | `false`                |
 | `fileClassName`               | Name of the Nutanix Files Storage Class                                                     | `nutanix-file`         |
 | `fileClassRetention`          | Retention policy for the Files Storage Class (Delete, Retain)                               | `Delete`               |
-| `dynFileSquashType`           | Squash type for Nutanix Dynamic File Storage (none, root-squash, all-squash)                | `root-squash`          |
+| `dynamicFileSquashType`       | Squash type for Nutanix Dynamic File Storage (none, root-squash, all-squash)                | `root-squash`          |
 | `dynamicFileClass`            | Activate Nutanix Dynamic Files Storage Class                                                | `false`                |
 | `dynamicFileClassName`        | Name of the Nutanix Dynamic Files Storage Class                                             | `nutanix-dynamicfile`  |
 | `dynamicFileClassDescription` | Description prefix for each created Fileshare                                               | `dynamicFileClassName` |

--- a/charts/nutanix-csi-storage/questions.yml
+++ b/charts/nutanix-csi-storage/questions.yml
@@ -123,8 +123,9 @@ questions:
     show_if: "dynamicFileClass=true"
   - variable: dynamicFileSquashType
     label: "Squash Type for NFS"
-    type: string
-    required: false
+    type: enum
+    default: "root-squash"
+    options: ["root-squash", "all-squash", "none"]
     description: "Specify Nutanix Files Squash Type"
     group: "Nutanix Files Settings"
     show_if: "dynamicFileClass=true"

--- a/charts/nutanix-csi-storage/questions.yml
+++ b/charts/nutanix-csi-storage/questions.yml
@@ -121,3 +121,10 @@ questions:
     description: "Specify Nutanix Files server name"
     group: "Nutanix Files Settings"
     show_if: "dynamicFileClass=true"
+  - variable: dynamicFileSquashType
+    label: "Squash Type for NFS"
+    type: string
+    required: false
+    description: "Specify Nutanix Files Squash Type"
+    group: "Nutanix Files Settings"
+    show_if: "dynamicFileClass=true"

--- a/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
@@ -55,6 +55,7 @@ metadata:
 provisioner: {{ include "nutanix-csi-storage.drivername" . }}
 parameters:
     storageType: NutanixFiles
+    squashType: {{ .Values.fileSquashType }}
     nfsServer: {{ .Values.fileHost }}
     nfsPath: {{ .Values.filePath }}
 reclaimPolicy: {{ .Values.fileClassRetention }}
@@ -73,6 +74,7 @@ provisioner: {{ include "nutanix-csi-storage.drivername" . }}
 parameters:
     storageType: NutanixFiles
     dynamicProv: ENABLED
+    squashType: {{ .Values.dynSquashType }}
     nfsServerName: {{ .Values.fileServerName }}
     csi.storage.k8s.io/provisioner-secret-name: {{ .Values.secretName }}
     csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}

--- a/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
@@ -55,7 +55,6 @@ metadata:
 provisioner: {{ include "nutanix-csi-storage.drivername" . }}
 parameters:
     storageType: NutanixFiles
-    squashType: {{ .Values.fileSquashType }}
     nfsServer: {{ .Values.fileHost }}
     nfsPath: {{ .Values.filePath }}
 reclaimPolicy: {{ .Values.fileClassRetention }}

--- a/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
@@ -74,7 +74,7 @@ provisioner: {{ include "nutanix-csi-storage.drivername" . }}
 parameters:
     storageType: NutanixFiles
     dynamicProv: ENABLED
-    squashType: {{ .Values.dynSquashType }}
+    squashType: {{ .Values.dynFileSquashType }}
     nfsServerName: {{ .Values.fileServerName }}
     csi.storage.k8s.io/provisioner-secret-name: {{ .Values.secretName }}
     csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}

--- a/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-sc.yaml
@@ -73,7 +73,7 @@ provisioner: {{ include "nutanix-csi-storage.drivername" . }}
 parameters:
     storageType: NutanixFiles
     dynamicProv: ENABLED
-    squashType: {{ .Values.dynFileSquashType }}
+    squashType: {{ .Values.dynamicFileSquashType }}
     nfsServerName: {{ .Values.fileServerName }}
     csi.storage.k8s.io/provisioner-secret-name: {{ .Values.secretName }}
     csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -82,11 +82,16 @@ networkSegmentation: false
 #
 fileHost: 10.0.0.3
 filePath: share
+# Squash-type for files. 
+# Values are: none, root-squash, all-squash. Default is root-squash
+fileSquashType: root-squash
 
 # Dynamic Files Settings
 #
 fileServerName: file
-
+# Squash-type for dynamic files. 
+# Values are: none, root-squash, all-squash. Default is root-squash
+dynSquashType: root-squash
 
 # Volume metrics and CSI operations metrics configuration
 #

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -87,7 +87,7 @@ filePath: share
 #
 fileServerName: file
 
-# Squash-type for dynamic files. 
+# Squash-type for dynamic files.
 # Values are: none, root-squash, all-squash. Default is root-squash
 dynamicFileSquashType: root-squash
 

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -126,7 +126,7 @@ sidecars:
     image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
     imageBeta: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
   resizer:
-    image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+    image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
   livenessprobe:
     image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
 

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -91,7 +91,7 @@ fileSquashType: root-squash
 fileServerName: file
 # Squash-type for dynamic files. 
 # Values are: none, root-squash, all-squash. Default is root-squash
-dynSquashType: root-squash
+dynFileSquashType: root-squash
 
 # Volume metrics and CSI operations metrics configuration
 #

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -82,9 +82,6 @@ networkSegmentation: false
 #
 fileHost: 10.0.0.3
 filePath: share
-# Squash-type for files. 
-# Values are: none, root-squash, all-squash. Default is root-squash
-fileSquashType: root-squash
 
 # Dynamic Files Settings
 #

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -107,12 +107,12 @@ servicemonitor:
 
 controller:
   replicas: 2
-  image: quay.io/karbon/ntnx-csi:v2.5.1
+  image: quay.io/karbon/ntnx-csi:v2.6.0
   nodeSelector: {}
   tolerations: []
 
 node:
-  image: quay.io/karbon/ntnx-csi:v2.5.1
+  image: quay.io/karbon/ntnx-csi:v2.6.0
   nodeSelector: {}
   tolerations: []
 
@@ -120,7 +120,7 @@ sidecars:
   registrar:
     image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
   provisioner:
-    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0
+    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
     imageLegacy: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
   snapshotter:
     image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -86,9 +86,10 @@ filePath: share
 # Dynamic Files Settings
 #
 fileServerName: file
+
 # Squash-type for dynamic files. 
 # Values are: none, root-squash, all-squash. Default is root-squash
-dynFileSquashType: root-squash
+dynamicFileSquashType: root-squash
 
 # Volume metrics and CSI operations metrics configuration
 #


### PR DESCRIPTION
Added support to specify/modify the squash type for Nutanix Files Storage and Nutanix Dynamic Files Storage in helm values.