### PR TITLE
Helm chart upgrades for CSI-v2.6.1 release

### DIFF
--- a/charts/nutanix-csi-storage/Chart.yaml
+++ b/charts/nutanix-csi-storage/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nutanix-csi-storage
-version: 2.6.0
+version: 2.6.1
 kubeVersion: ">= 1.17.0-0"
 description: Nutanix Container Storage Interface (CSI) Driver
 home: https://github.com/nutanix/helm
@@ -8,7 +8,7 @@ maintainers:
   - name: nutanix-cloud-native-bot
     email: cloudnative@nutanix.com
 icon: https://avatars2.githubusercontent.com/u/6165865?s=200&v=4
-appVersion: "2.6.0"
+appVersion: "2.6.1"
 keywords:
   - Nutanix
   - Storage

--- a/charts/nutanix-csi-storage/Chart.yaml
+++ b/charts/nutanix-csi-storage/Chart.yaml
@@ -23,7 +23,7 @@ annotations:
   artifacthub.io/displayName: "Nutanix CSI Storage"
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - Update Nutanix CSI driver to v2.6
+    - Update Nutanix CSI driver to v2.6.1
     - Update CSI Sidecar version
   artifacthub.io/links: |
     - name: Nutanix CSI Driver documentation

--- a/charts/nutanix-csi-storage/README.md
+++ b/charts/nutanix-csi-storage/README.md
@@ -25,7 +25,7 @@ https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v2_
 
 ## Features list
 
-- Nutanix CSI Driver v2.6.0
+- Nutanix CSI Driver v2.6.1
 - Nutanix Volumes support
 - Nutanix Files support
 - Volume clone

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -121,12 +121,12 @@ servicemonitor:
 
 controller:
   replicas: 2
-  image: quay.io/karbon/ntnx-csi:v2.6.0
+  image: quay.io/karbon/ntnx-csi:v2.6.1
   nodeSelector: {}
   tolerations: []
 
 node:
-  image: quay.io/karbon/ntnx-csi:v2.6.0
+  image: quay.io/karbon/ntnx-csi:v2.6.1
   nodeSelector: {}
   tolerations: []
 

--- a/charts/nutanix-csi-storage/values.yaml
+++ b/charts/nutanix-csi-storage/values.yaml
@@ -132,17 +132,17 @@ node:
 
 sidecars:
   registrar:
-    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+    image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.0
   provisioner:
-    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
     imageLegacy: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
   snapshotter:
-    image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+    image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
     imageBeta: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
   resizer:
     image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
   livenessprobe:
-    image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+    image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
 
 # Used for deployment test in kind cluster
 #


### PR DESCRIPTION
Changes introduced:
1. Bump versions to support csi-v2.6.1
2. Upgraded CSI images.