### PR TITLE
Remove terminationGracePeriodSeconds duplicated key

### DIFF
--- a/charts/ndb-operator/Chart.yaml
+++ b/charts/ndb-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ndb-operator
 description: A Helm chart for Nutanix Database Kubernetes Operator
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.5.0
 maintainers:
   - name: mazin-s

--- a/charts/ndb-operator/templates/deployment-ndb-operator-controller-manager.yaml
+++ b/charts/ndb-operator/templates/deployment-ndb-operator-controller-manager.yaml
@@ -96,4 +96,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
When using tools like Flux, the parser fails because there is a duplicated JSON key. When using helm it doesn't fails because K8s is more permissive than the parsers.