### PR TITLE
feat: add OCI support for pushing charts to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,29 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Install Helm
+        uses: jdx/mise-action@v3
+        with:
+          tool_versions: |
+            helm: latest
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -f "$pkg" ]; then
+              helm push "$pkg" oci://ghcr.io/nutanix-cloud-native/chart
+            fi
+          done


### PR DESCRIPTION
This pull request updates the release workflow to improve Helm chart publishing automation. The main changes include adding a step to ensure the latest version of Helm is available and a new step to push Helm charts to GitHub Container Registry (GHCR) after release.

**Helm tooling and publishing improvements:**

* Added a `jdx/mise-action` step to install the latest version of `helm` before running chart release steps in `.github/workflows/release.yml`.
* Added a step to push released Helm chart packages to GHCR using `helm push` after the chart-releaser action completes.